### PR TITLE
Disable digit grouping on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v0.1.8
+- Disable digit grouping on Android
+
 v0.1.7
 - Fix indexing bug
 

--- a/lib/src/iban_form_field.dart
+++ b/lib/src/iban_form_field.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -226,7 +228,9 @@ class _IbanFormFieldState extends State<IbanFormFieldBuilder> {
                   ),
                   LengthLimitingTextInputFormatter(
                       widget.state.value.maxBasicBankAccountNumberLength),
-                  SpacedTextInputFormatter(),
+                  // Due to a flutter issue, c.f. commit message
+                  if (Platform.isIOS)
+                    SpacedTextInputFormatter(),
                 ],
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iban_form_field
 description: An IBAN form which deals with spacing and country specific rules.
-version: 0.1.7
+version: 0.1.8
 author: inapay POS authors <info@inapay.com>
 homepage: https://github.com/inapay/iban_form_field
 


### PR DESCRIPTION
Adding spaces to group digits into groups of four
introduces an unresolved Flutter keyboard issue
on Android.
https://github.com/flutter/flutter/issues/30008